### PR TITLE
feat: Add support to fragments

### DIFF
--- a/src/tests/_data_/dataTypes.ts
+++ b/src/tests/_data_/dataTypes.ts
@@ -11,7 +11,6 @@ export interface Scalars {
   Int: number
   Float: number
 }
-
 export interface Mutation {
   __typename?: 'Mutation'
   createTodo?: Maybe<Todo>
@@ -35,15 +34,18 @@ export interface MutationToggleTodoArgs {
 export interface MutationUpdateTodoArgs {
   input: TodoInput
 }
-
 export interface Query {
   __typename?: 'Query'
-  todo?: Maybe<Todo>
+  todo?: Maybe<TodoResult>
+  todoByName?: Maybe<Todo>
   todos?: Maybe<Array<Maybe<Todo>>>
 }
-
 export interface QueryTodoArgs {
   todoId?: InputMaybe<Scalars['ID']>
+}
+
+export interface QueryTodoByNameArgs {
+  name?: InputMaybe<Scalars['String']>
 }
 
 export interface Todo {
@@ -58,3 +60,10 @@ export interface TodoInput {
   name?: InputMaybe<Scalars['String']>
   todoId?: InputMaybe<Scalars['ID']>
 }
+
+export interface TodoNotFoundError {
+  __typename?: 'TodoNotFoundError'
+  message: Scalars['String']
+}
+
+export type TodoResult = Todo | TodoNotFoundError

--- a/src/tests/intex.test.ts
+++ b/src/tests/intex.test.ts
@@ -1,10 +1,10 @@
 import { graphql } from '../builder'
 import OperationType from '../operationType'
-import { Todo, QueryTodoArgs, MutationCreateTodoArgs } from './_data_/dataTypes'
+import { Todo, QueryTodoArgs, MutationCreateTodoArgs, TodoResult } from './_data_/dataTypes'
 
 describe('test query', () => {
   it('should return a query', () => {
-    const query = graphql<Todo>({
+    const [query] = graphql<Todo>({
       name: 'todos',
       fields: [
         'id',
@@ -16,8 +16,51 @@ describe('test query', () => {
     expect(query).toBe('query { todos { id name complete } }')
   })
 
+  it('should return a query without fragments when fragment is false', () => {
+    const [query, variables] = graphql<Todo, QueryTodoArgs>({
+      name: 'todo',
+      fields: [
+        {
+          type: 'Todo',
+          value: ['id', 'name'],
+          fragment: false
+        }
+      ],
+      variables: {
+        todoId: '123'
+      }
+    })
+
+    expect(query).toBe('query ($todoId: String) { todo (todoId: $todoId) { ...on Todo { id name } ...on TodoNotFoundError { message } } }')
+    expect(variables).toBe('{ "todoId": 1 }')
+  })
+
+  it('should return a query with fragments when fragment is true', () => {
+    const [query, variables] = graphql<TodoResult, QueryTodoArgs>({
+      name: 'todo',
+      fields: [
+        {
+          type: 'Todo',
+          value: ['id', 'name'],
+          fragment: true
+        },
+        {
+          type: 'TodoNotFoundError',
+          fragment: true,
+          value: ['message']
+        }
+      ],
+      variables: {
+        todoId: '123'
+      }
+    })
+
+    expect(query).toBe('query ($todoId: String) { todo (todoId: $todoId) { ...on Todo { id name } ...on TodoNotFoundError { message } } }')
+    expect(variables).toBe('{ "todoId": 1 }')
+  })
+
   it('should return a query with variables', () => {
-    const query = graphql<Todo, QueryTodoArgs>({
+    const [query, variables] = graphql<Todo, QueryTodoArgs>({
       name: 'todos',
       fields: [
         'id',
@@ -33,11 +76,12 @@ describe('test query', () => {
       }
     })
 
-    expect(query).toBe('query ($todoId: ID!) { todos (todoId: $todoId) { id name complete } } \n\n { "todoId": 1 }')
+    expect(query).toBe('query ($todoId: ID!) { todos (todoId: $todoId) { id name complete } }')
+    expect(variables).toBe('{ "todoId": 1 }')
   })
 
   it('should return a mutation with variables', () => {
-    const query = graphql<Todo, MutationCreateTodoArgs>({
+    const [query, variables] = graphql<Todo, MutationCreateTodoArgs>({
       operation: OperationType.Mutation,
       name: 'createTodo',
       fields: [
@@ -58,6 +102,7 @@ describe('test query', () => {
       }
     })
 
-    expect(query).toBe('mutation ($input: TodoInput!) { createTodo (input: $input) { id name complete } } \n\n { "input": { "complete": false, "name": "test", "todoId": "123" } }')
+    expect(query).toBe('mutation ($input: TodoInput!) { createTodo (input: $input) { id name complete } }')
+    expect(variables).toBe('{ "input": { "complete": false, "name": "test", "todoId": "123" } }')
   })
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,13 @@
-type ObjectField<T, K extends keyof any> = {
-  [P in K]: Fields<T>
+interface ObjectField<T, K extends keyof T> {
+  type: T[K]
+  value: Array<Field<T>>
+  fragment: boolean
 }
 
+type KeysOfUnion<T> = T extends T ? keyof T : never
+
 type Field<T> = {
-  [K in keyof T]: T[K] extends object ? ObjectField<T[K], K> : K
+  [K in keyof T]: KeysOfUnion<T> | ObjectField<T, K>
 }[keyof T]
 
 export type Fields<T> = Array<Field<T>>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
     "noUnusedLocals": true
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "build", "src/tests"]
+  "exclude": ["node_modules", "build"]
 }


### PR DESCRIPTION
Adding fragment support with an optional object works like the variable object.
Changing the `graphql` function return to an array with two strings as elements, the first the query and the second the variables.   